### PR TITLE
Add displayName to composers

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -133,7 +133,7 @@ export default function compose(dataLoader, options = {}) {
       dataLoader, options,
     };
 
-    inheritStatics(Container, Child);
+    inheritStatics(Container, Child, options.displayName);
     return mayBeStubbed(Container);
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@
 
 import hoistStatics from 'hoist-non-react-statics';
 
-export function inheritStatics(Container, ChildComponent) {
+export function inheritStatics(Container, ChildComponent, displayName = 'Container') {
   const childDisplayName =
       // Get the display name if it's set.
       ChildComponent.displayName ||
@@ -11,6 +11,6 @@ export function inheritStatics(Container, ChildComponent) {
       // If not, just add a default one.
       'ChildComponent';
 
-  Container.displayName = `Container(${childDisplayName})`; // eslint-disable-line
+  Container.displayName = `${displayName}(${childDisplayName})`; // eslint-disable-line
   return hoistStatics(Container, ChildComponent);
 }


### PR DESCRIPTION
# Problem

I can't define the display-name of the middle container in some cases, having to stick with a `MyContainer -> Container(MyComponent) -> MyComponent` pattern.

<img width="250" alt="screen shot 2016-12-02 at 14 06 29" src="https://cloud.githubusercontent.com/assets/181076/20835041/afb668fc-b898-11e6-9551-dde60a085166.png">

# Solution


Inspired by [react-komposer-plus](https://github.com/sammkj/react-komposer-plus), the goal is to be able to define the display-name in the composers, as seen [here](https://github.com/sammkj/react-komposer-plus/blob/98fc72fc363c41ea52a07f6fe9dc3a11d55a76d7/src/composers/withReduxState.js#L29). The pattern would then become `MyContainer -> withRedux(MyComponent) -> MyComponent`.
